### PR TITLE
Add summary cards to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,47 @@
                 </div>
             </section>
 
+            <!-- Quick Stats for Main Menus -->
+            <section class="quick-stats">
+                <div class="summary-grid">
+                    <div class="dashboard-card stat-card mwp-stat" onclick="window.location.href='mwp.html'">
+                        <div class="stat-icon"><i class="fas fa-calendar-alt"></i></div>
+                        <div class="stat-info">
+                            <span class="stat-title">MWP</span>
+                            <span class="stat-value">3 drafts</span>
+                        </div>
+                    </div>
+                    <div class="dashboard-card stat-card travel-stat" onclick="window.location.href='travel.html'">
+                        <div class="stat-icon"><i class="fas fa-plane"></i></div>
+                        <div class="stat-info">
+                            <span class="stat-title">Travel</span>
+                            <span class="stat-value">1 upcoming</span>
+                        </div>
+                    </div>
+                    <div class="dashboard-card stat-card vehicle-stat" onclick="window.location.href='vehicle.html'">
+                        <div class="stat-icon"><i class="fas fa-car"></i></div>
+                        <div class="stat-info">
+                            <span class="stat-title">Vehicle</span>
+                            <span class="stat-value">3 pending</span>
+                        </div>
+                    </div>
+                    <div class="dashboard-card stat-card expense-stat" onclick="window.location.href='expenses.html'">
+                        <div class="stat-icon"><i class="fas fa-receipt"></i></div>
+                        <div class="stat-info">
+                            <span class="stat-title">Expenses</span>
+                            <span class="stat-value">2 drafts</span>
+                        </div>
+                    </div>
+                    <div class="dashboard-card stat-card approval-stat" onclick="window.location.href='approvals.html'">
+                        <div class="stat-icon"><i class="fas fa-check-circle"></i></div>
+                        <div class="stat-info">
+                            <span class="stat-title">Approvals</span>
+                            <span class="stat-value">5 pending</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <!-- Row 1: Hero Cards -->
             <section class="hero-row">
                 <div class="card-grid">

--- a/style.css
+++ b/style.css
@@ -1269,6 +1269,49 @@ textarea:focus {
     box-shadow: 0 4px 16px rgba(0,0,0,0.15);
 }
 
+/* Quick Stats Summary Cards */
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.stat-card {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+}
+
+.stat-icon {
+    font-size: 1.5rem;
+    padding: 0.5rem;
+    border-radius: 50%;
+    color: #fff;
+}
+
+.stat-info {
+    text-align: right;
+}
+
+.stat-title {
+    font-size: 0.9rem;
+    color: var(--ink-700);
+}
+
+.stat-value {
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: var(--ink-900);
+}
+
+.mwp-stat .stat-icon { background: var(--brand-primary); }
+.travel-stat .stat-icon { background: var(--brand-teal); }
+.vehicle-stat .stat-icon { background: var(--success); }
+.expense-stat .stat-icon { background: var(--warning); }
+.approval-stat .stat-icon { background: var(--danger); }
+
 .card-header {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- Add quick stats cards for MWP, Travel, Vehicle, Expenses, and Approvals with icons and colors
- Introduce responsive grid styling for new summary cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0eeb09883289d84e40c24ab1b90