### PR TITLE
Add placeholder schedule table

### DIFF
--- a/announcements.html
+++ b/announcements.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pengumuman - TrevID</title>
+    <title>Announcements - TrevID</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link href="style.css" rel="stylesheet">
 </head>
@@ -66,10 +66,10 @@
     <main class="main-content">
         <div class="container">
             <section class="announcement-detail">
-                <h1>Pengumuman</h1>
-                <p>Berikut adalah pengumuman terbaru mengenai kebijakan perjalanan bisnis.</p>
-                <p>Pastikan Anda membaca dan memahami setiap poin yang disampaikan.</p>
-                <p>Hubungi administrator jika ada pertanyaan lebih lanjut.</p>
+                <h1>Announcements</h1>
+                <p>Below are the latest announcements regarding business travel policies.</p>
+                <p>Please read and understand each point.</p>
+                <p>Contact the administrator if you have further questions.</p>
             </section>
         </div>
     </main>

--- a/index.html
+++ b/index.html
@@ -102,13 +102,46 @@
             <!-- Announcement Card -->
             <section class="announcement-section">
                 <div class="dashboard-card announcement-card">
-                    <h2>Pengumuman</h2>
+                    <h2>Announcements</h2>
                     <div class="announcement-content">
-                        <p>Pembaruan sistem akan dilakukan pada akhir pekan ini.</p>
-                        <p>Silakan selesaikan pengajuan biaya Anda sebelum hari Jumat.</p>
-                        <p>Kebijakan perjalanan baru telah diterbitkan.</p>
+                        <p>System updates will be performed this weekend.</p>
+                        <p>Please submit your expense reports before Friday.</p>
+                        <p>The new travel policy has been published.</p>
                     </div>
-                    <a href="pengumuman.html" class="btn btn-primary announcement-btn">Lihat Semua</a>
+                    <a href="announcements.html" class="btn btn-primary announcement-btn">View All</a>
+                </div>
+            </section>
+
+            <!-- Placeholder Schedule Section -->
+            <section class="schedule-section">
+                <div class="dashboard-card schedule-card">
+                    <h2>Activity Schedule</h2>
+                    <table class="schedule-table">
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Description</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>2024-01-01</td>
+                                <td>Sample activity 1</td>
+                                <td>Pending</td>
+                            </tr>
+                            <tr>
+                                <td>2024-02-15</td>
+                                <td>Sample activity 2</td>
+                                <td>In Progress</td>
+                            </tr>
+                            <tr>
+                                <td>2024-03-30</td>
+                                <td>Sample activity 3</td>
+                                <td>Completed</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add simple schedule section with placeholder rows for future data
- translate placeholder table and announcement content to English and rename announcement page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b6ee3f4c8328bab0bbb8a42bfb7d