### PR TITLE
Add aria-current attribute for active navigation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -48,7 +48,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="admin.html" class="nav-item active">
+        <a href="admin.html" class="nav-item active" aria-current="page">
             <i class="fas fa-cog"></i>
             <span>Admin</span>
         </a>

--- a/approvals.html
+++ b/approvals.html
@@ -698,7 +698,7 @@
             <i class="fas fa-money-bill"></i>
             <span>Cash Advance</span>
         </a>
-        <a href="approvals.html" class="nav-item active">
+        <a href="approvals.html" class="nav-item active" aria-current="page">
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>

--- a/approvals_2.html
+++ b/approvals_2.html
@@ -48,7 +48,7 @@
             <i class="fas fa-money-bill"></i>
             <span>Cash Advance</span>
         </a>
-        <a href="approvals.html" class="nav-item active">
+        <a href="approvals.html" class="nav-item active" aria-current="page">
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>

--- a/audit-log.html
+++ b/audit-log.html
@@ -50,7 +50,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="audit-log.html" class="nav-item active">
+        <a href="audit-log.html" class="nav-item active" aria-current="page">
             <i class="fas fa-history"></i>
             <span>Audit Log</span>
         </a>

--- a/cash-advance.html
+++ b/cash-advance.html
@@ -565,7 +565,7 @@
             <i class="fas fa-receipt"></i>
             <span>Expenses</span>
         </a>
-        <a href="cash-advance.html" class="nav-item active">
+        <a href="cash-advance.html" class="nav-item active" aria-current="page">
             <i class="fas fa-money-bill-wave"></i>
             <span>Cash Advance</span>
         </a>

--- a/expense-detail.html
+++ b/expense-detail.html
@@ -284,7 +284,7 @@
             <i class="fas fa-car"></i>
             <span>Vehicle</span>
         </a>
-        <a href="expenses.html" class="nav-item active">
+        <a href="expenses.html" class="nav-item active" aria-current="page">
             <i class="fas fa-receipt"></i>
             <span>Expenses</span>
         </a>

--- a/expense-form.html
+++ b/expense-form.html
@@ -100,7 +100,7 @@
             <i class="fas fa-car"></i>
             <span>Vehicle</span>
         </a>
-        <a href="expenses.html" class="nav-item active">
+        <a href="expenses.html" class="nav-item active" aria-current="page">
             <i class="fas fa-receipt"></i>
             <span>Expenses</span>
         </a>

--- a/expenses.html
+++ b/expenses.html
@@ -43,7 +43,7 @@
             <i class="fas fa-car"></i>
             <span>Vehicle</span>
         </a>
-        <a href="expenses.html" class="nav-item active">
+        <a href="expenses.html" class="nav-item active" aria-current="page">
             <i class="fas fa-receipt"></i>
             <span>Expenses</span>
         </a>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 
     <!-- Navigation -->
     <nav class="bottom-nav">
-        <a href="index.html" class="nav-item active">
+        <a href="index.html" class="nav-item active" aria-current="page">
             <i class="fas fa-home"></i>
             <span>Dashboard</span>
         </a>

--- a/mwp.html
+++ b/mwp.html
@@ -35,7 +35,7 @@
             <i class="fas fa-home"></i>
             <span>Dashboard</span>
         </a>
-        <a href="mwp.html" class="nav-item active">
+        <a href="mwp.html" class="nav-item active" aria-current="page">
             <i class="fas fa-calendar-alt"></i>
             <span>MWP</span>
         </a>

--- a/profile-old.html
+++ b/profile-old.html
@@ -47,7 +47,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="profile.html" class="nav-item active">
+        <a href="profile.html" class="nav-item active" aria-current="page">
             <i class="fas fa-user"></i>
             <span>Profile</span>
         </a>

--- a/profile.html
+++ b/profile.html
@@ -1235,7 +1235,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="profile.html" class="nav-item active">
+        <a href="profile.html" class="nav-item active" aria-current="page">
             <i class="fas fa-user"></i>
             <span>Profile</span>
         </a>

--- a/receipts.html
+++ b/receipts.html
@@ -51,7 +51,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="receipts.html" class="nav-item active">
+        <a href="receipts.html" class="nav-item active" aria-current="page">
             <i class="fas fa-file-image"></i>
             <span>Receipts</span>
         </a>

--- a/reports.html
+++ b/reports.html
@@ -51,7 +51,7 @@
             <i class="fas fa-check-circle"></i>
             <span>Approvals</span>
         </a>
-        <a href="reports.html" class="nav-item active">
+        <a href="reports.html" class="nav-item active" aria-current="page">
             <i class="fas fa-chart-bar"></i>
             <span>Reports</span>
         </a>

--- a/script.js
+++ b/script.js
@@ -173,12 +173,26 @@ function updateUserInfo() {
 function initializeNavigation() {
     // Add click handlers for navigation items
     const navItems = document.querySelectorAll('.nav-item');
+
+    // Ensure the correct aria-current is set on load
+    navItems.forEach(nav => {
+        if (nav.classList.contains('active')) {
+            nav.setAttribute('aria-current', 'page');
+        } else {
+            nav.removeAttribute('aria-current');
+        }
+    });
+
     navItems.forEach(item => {
         item.addEventListener('click', function(e) {
-            // Remove active class from all items
-            navItems.forEach(nav => nav.classList.remove('active'));
-            // Add active class to clicked item
+            // Remove active class and aria-current from all items
+            navItems.forEach(nav => {
+                nav.classList.remove('active');
+                nav.removeAttribute('aria-current');
+            });
+            // Add active class and aria-current to clicked item
             this.classList.add('active');
+            this.setAttribute('aria-current', 'page');
         });
     });
 }

--- a/travel.html
+++ b/travel.html
@@ -34,7 +34,7 @@
             <i class="fas fa-home"></i>
             <span>Dashboard</span>
         </a>
-        <a href="travel.html" class="nav-item active">
+        <a href="travel.html" class="nav-item active" aria-current="page">
             <i class="fas fa-plane"></i>
             <span>Travel</span>
         </a>

--- a/vehicle.html
+++ b/vehicle.html
@@ -502,7 +502,7 @@
             <i class="fas fa-plane"></i>
             <span>Travel</span>
         </a>
-        <a href="vehicle.html" class="nav-item active">
+        <a href="vehicle.html" class="nav-item active" aria-current="page">
             <i class="fas fa-car"></i>
             <span>Vehicle</span>
             <span class="nav-badge warning" id="badge-vehicle" data-count="1" title="1 policy violation">1</span>


### PR DESCRIPTION
## Summary
- Add `aria-current="page"` to active navigation links across pages for better accessibility
- Enhance `initializeNavigation` to manage `aria-current` alongside `active` class on click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898bbc82864832884d5fd0fa764bcec