### PR TITLE
Fix header layout spacing on MWP page

### DIFF
--- a/style.css
+++ b/style.css
@@ -441,6 +441,7 @@ textarea:focus {
     align-items: center;
     justify-content: space-between;
     padding: 12px 16px;
+    width: 100%;
 }
 
 .header .container .quick-actions-desktop {


### PR DESCRIPTION
## Summary
- Ensure header container spans full width so logo and greeting align left and right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d7625fc083289051722d5d008d7d